### PR TITLE
Fixes: #20, #21 and #26

### DIFF
--- a/src/ext/expression_ext.rs
+++ b/src/ext/expression_ext.rs
@@ -1,72 +1,8 @@
 use crate::component::MARKER_SUFFIX;
 use oxc_ast::ast::Expression;
-use oxc_semantic::SymbolId;
-use oxc_traverse::TraverseCtx;
-use std::collections::HashSet;
 
 pub trait ExpressionExt {
     fn is_qrl_replaceable(&self) -> bool;
-    fn get_referenced_symbols(&self, ctx: &mut TraverseCtx) -> HashSet<SymbolId>;
-}
-
-fn walk_referenced_symbols(
-    expression: &Expression,
-    symbols: &mut HashSet<SymbolId>,
-    ctx: &mut TraverseCtx,
-) {
-    match expression {
-        Expression::BooleanLiteral(_) => {}
-        Expression::NullLiteral(_) => {}
-        Expression::NumericLiteral(_) => {}
-        Expression::BigIntLiteral(_) => {}
-        Expression::RegExpLiteral(_) => {}
-        Expression::StringLiteral(_) => {}
-        Expression::TemplateLiteral(_) => {}
-        Expression::Identifier(id_ref) => {
-            if !id_ref.name.ends_with("$") {
-                let ref_id = id_ref.reference_id();
-                if let Some(symbol_id) = ctx.symbols().get_reference(ref_id).symbol_id() {
-                    symbols.insert(symbol_id);
-                }
-            }
-        }
-        Expression::MetaProperty(_) => {}
-        Expression::Super(_) => {}
-        Expression::ArrayExpression(_) => {}
-        Expression::ArrowFunctionExpression(_) => {}
-        Expression::AssignmentExpression(_) => {}
-        Expression::AwaitExpression(_) => {}
-        Expression::BinaryExpression(_) => {}
-        Expression::CallExpression(_) => {}
-        Expression::ChainExpression(_) => {}
-        Expression::ClassExpression(_) => {}
-        Expression::ConditionalExpression(_) => {}
-        Expression::FunctionExpression(_) => {}
-        Expression::ImportExpression(_) => {}
-        Expression::LogicalExpression(_) => {}
-        Expression::NewExpression(_) => {}
-        Expression::ObjectExpression(_) => {}
-        Expression::ParenthesizedExpression(_) => {}
-        Expression::SequenceExpression(_) => {}
-        Expression::TaggedTemplateExpression(_) => {}
-        Expression::ThisExpression(_) => {}
-        Expression::UnaryExpression(_) => {}
-        Expression::UpdateExpression(_) => {}
-        Expression::YieldExpression(_) => {}
-        Expression::PrivateInExpression(_) => {}
-        Expression::JSXElement(_) => {}
-        Expression::JSXFragment(_) => {}
-        Expression::TSAsExpression(_) => {}
-        Expression::TSSatisfiesExpression(_) => {}
-        Expression::TSTypeAssertion(_) => {}
-        Expression::TSNonNullExpression(_) => {}
-        Expression::TSInstantiationExpression(_) => {}
-        Expression::ComputedMemberExpression(_) => {}
-        Expression::StaticMemberExpression(expr) => {
-            walk_referenced_symbols(&expr.object, symbols, ctx);
-        }
-        Expression::PrivateFieldExpression(_) => {}
-    }
 }
 
 impl ExpressionExt for Expression<'_> {
@@ -80,11 +16,5 @@ impl ExpressionExt for Expression<'_> {
         } else {
             false
         }
-    }
-
-    fn get_referenced_symbols(&self, ctx: &mut TraverseCtx) -> HashSet<SymbolId> {
-        let mut symbols = HashSet::new();
-        walk_referenced_symbols(self, &mut symbols, ctx);
-        symbols
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,17 +16,20 @@ macro_rules! function_name {
 macro_rules! _assert_valid_transform {
     ($input:literal) => {{
         let func_name = function_name!();
-        let path = PathBuf::from("./src/test_input").join(format!("{func_name}.tsx"));
+        let mut path = PathBuf::from("./src/test_input").join(format!("{func_name}.tsx"));
+        let mut lang = crate::component::Language::Typescript;
+
+        if !path.exists() {
+            path = PathBuf::from("./src/test_input").join(format!("{func_name}.js"));
+            lang = crate::component::Language::Javascript;
+        }
+
         println!("Loading test input file from path: {:?}", &path);
 
         let source_code = std::fs::read_to_string(&path).unwrap();
 
-        let source_input = Source::from_source(
-            source_code,
-            crate::component::Language::Typescript,
-            Some("test".to_string()),
-        )
-        .unwrap();
+        let source_input =
+            Source::from_source(source_code, lang, Some("test".to_string())).unwrap();
         let result = transform(source_input).unwrap();
 
         if $input == true {

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -3,43 +3,175 @@ use oxc_allocator::{Allocator, Box as OxcBox, FromIn};
 use oxc_ast::ast::{BindingIdentifier, BindingPattern, BindingPatternKind, TSTypeAnnotation};
 use oxc_ast::AstBuilder;
 use oxc_span::SPAN;
+use std::collections::HashMap;
 use std::fmt::Display;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum Segment {
     Named(String),
-    /// Represents a component captured by the `$` function.
-    AnonymousCaptured,
     /// Represents a named capture with the `$` suffix e.g. `component$`, `foo$`.
-    NamedCaptured(String),
+    /// The `usize` is the number of times the prefix appears within the same segment scope and
+    /// allows for the creation of unique names.
+    NamedQrl(String, usize),
+    /// Represents a segment that has been made unique by adding an index .e.g `_1`, `_2`, etc..
+    /// This is only used for case where an unanchored QRL's, `$`, name needs to be made unique.
+    IndexQrl(usize),
+}
+
+enum UniqueName {
+    Name(String, usize),
+    Index(usize),
+}
+
+pub(crate) struct SegmentBuilder {
+    names: HashMap<String, usize>,
+}
+
+fn make_fq_name(segment_names: &Vec<String>) -> String {
+    let mut fq_name = String::new();
+
+    for segment in segment_names {
+        if segment.trim().is_empty() {
+            continue;
+        }
+
+        if fq_name.is_empty()
+            && segment
+                .chars()
+                .next()
+                .map(|c| c.is_ascii_digit())
+                .unwrap_or(false)
+        {
+            fq_name = format!("_{}", segment);
+        } else {
+            let prefix: String = if fq_name.is_empty() {
+                "".to_string()
+            } else {
+                format!("{}_", fq_name).to_string()
+            };
+            fq_name = format!("{}{}", prefix, segment);
+        }
+    }
+
+    fq_name
+}
+
+fn make_unique_segment_name(
+    existing_segment_names: Vec<String>,
+    new_segment_name: &SegmentName,
+    names: &mut HashMap<String, usize>,
+) -> UniqueName {
+    let mut existing_segment_names = existing_segment_names;
+
+    if !matches!(new_segment_name, SegmentName::Name(_)) {
+        if let SegmentName::AnchoredQrl(ref name) = new_segment_name {
+            existing_segment_names.push(name.clone());
+        }
+        let fq_name = make_fq_name(&existing_segment_names);
+
+        match names.get_mut(fq_name.as_str()) {
+            None => match new_segment_name {
+                SegmentName::AnchoredQrl(name) => {
+                    names.insert(fq_name, 1);
+                    UniqueName::Name(name.clone(), 0)
+                }
+                SegmentName::UnanchoredQrl => {
+                    names.insert(fq_name, 1);
+                    UniqueName::Index(0)
+                }
+                SegmentName::Name(_) => unreachable!(),
+            },
+            Some(count) => match new_segment_name {
+                SegmentName::AnchoredQrl(name) => {
+                    let name = UniqueName::Name(name.clone(), count.clone());
+                    *count += 1;
+                    name
+                }
+                SegmentName::UnanchoredQrl => {
+                    let name = UniqueName::Index(count.clone());
+                    *count += 1;
+                    name
+                }
+                SegmentName::Name(_) => unreachable!(),
+            },
+        }
+    } else {
+        match &new_segment_name {
+            SegmentName::Name(name) => UniqueName::Name(name.clone(), 0),
+            SegmentName::AnchoredQrl(_) => unreachable!(),
+            SegmentName::UnanchoredQrl => unreachable!(),
+        }
+    }
+}
+
+enum SegmentName {
+    Name(String),
+    AnchoredQrl(String),
+    UnanchoredQrl,
+}
+
+impl SegmentName {
+    fn new(name0: String) -> Self {
+        let name = name0.strip_suffix(MARKER_SUFFIX);
+
+        match name {
+            None => SegmentName::Name(name0),
+            Some(name) if name.is_empty() => SegmentName::UnanchoredQrl,
+            Some(name) => SegmentName::AnchoredQrl(name.to_string()),
+        }
+    }
+
+    fn is_qrl(&self) -> bool {
+        match self {
+            SegmentName::AnchoredQrl(_) => true,
+            SegmentName::UnanchoredQrl => true,
+            SegmentName::Name(_) => false,
+        }
+    }
+}
+
+impl SegmentBuilder {
+    pub(crate) fn new() -> Self {
+        SegmentBuilder {
+            names: HashMap::new(),
+        }
+    }
+
+    pub fn new_segment<T: AsRef<str>>(&mut self, input: T, segments: &[Segment]) -> Segment {
+        let input = input.as_ref();
+        let segment_name = SegmentName::new(input.to_string());
+
+        let segment_names: Vec<String> = segments.iter().map(|s| s.into()).collect();
+
+        let unique_name = make_unique_segment_name(segment_names, &segment_name, &mut self.names);
+
+        match unique_name {
+            UniqueName::Name(name, index) => {
+                if segment_name.is_qrl() {
+                    Segment::NamedQrl(name, index)
+                } else {
+                    Segment::Named(name)
+                }
+            }
+            UniqueName::Index(index) => Segment::IndexQrl(index),
+        }
+    }
 }
 
 impl Segment {
-    fn new<T: AsRef<str>>(input: T) -> Segment {
-        let input = input.as_ref();
-        if input == MARKER_SUFFIX {
-            Segment::AnonymousCaptured
-        } else {
-            match input.strip_suffix(MARKER_SUFFIX) {
-                Some(name) => Segment::NamedCaptured(name.to_string()),
-                None => Segment::Named(input.into()),
-            }
-        }
-    }
-
-    pub fn is_qrl_extractable(&self) -> bool {
+    pub fn is_qrl(&self) -> bool {
         match self {
             Segment::Named(_) => false,
-            Segment::AnonymousCaptured => true,
-            Segment::NamedCaptured(_) => true,
+            Segment::NamedQrl(_, _) => true,
+            Segment::IndexQrl(_) => true,
         }
     }
 
-    pub fn associated_qrl_type(&self) -> QrlType {
+    pub fn qrl_type(&self) -> Option<QrlType> {
         match self {
-            Segment::Named(_) => QrlType::Qrl,
-            Segment::AnonymousCaptured => QrlType::Qrl,
-            Segment::NamedCaptured(prefix) => QrlType::PrefixedQrl(prefix.into()),
+            Segment::Named(_) => None,
+            Segment::NamedQrl(name, _) => Some(QrlType::PrefixedQrl(name.into())),
+            Segment::IndexQrl(index) => Some(QrlType::IndexedQrl(*index)),
         }
     }
 
@@ -47,10 +179,10 @@ impl Segment {
         let ast_builder = AstBuilder::new(allocator);
         match self {
             Segment::Named(name) => ast_builder.binding_identifier(SPAN, name),
-            Segment::AnonymousCaptured => ast_builder.binding_identifier(SPAN, MARKER_SUFFIX),
-            Segment::NamedCaptured(name) => {
+            Segment::NamedQrl(name, _) => {
                 ast_builder.binding_identifier(SPAN, format!("{}{}", name, MARKER_SUFFIX))
             }
+            Segment::IndexQrl(_) => ast_builder.binding_identifier(SPAN, MARKER_SUFFIX),
         }
     }
 
@@ -68,10 +200,10 @@ impl Segment {
 impl Display for Segment {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Segment::Named(name) => write!(f, "{}", name),
-            Segment::AnonymousCaptured => write!(f, ""),
-            Segment::NamedCaptured(name) => write!(f, "{}", name),
-            // Segment::ComponentCaptured => write!(f, "{}", COMPONENT),
+            Segment::Named(name) => write!(f, "{name}"),
+            Segment::NamedQrl(name, index) if *index == 0 => write!(f, "{name}"),
+            Segment::NamedQrl(name, index) => write!(f, "{name}_{index}"),
+            Segment::IndexQrl(index) => write!(f, "${index}"),
         }
     }
 }
@@ -82,28 +214,53 @@ impl<'a> FromIn<'a, Segment> for BindingPattern<'a> {
     }
 }
 
-impl<'a> FromIn<'a, &'a BindingPattern<'a>> for Segment {
-    fn from_in(value: &'a BindingPattern<'a>, _a: &'a Allocator) -> Self {
-        let s: String = value
-            .get_identifier_name()
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
-        Segment::new(s)
-    }
-}
-
 impl From<&Segment> for String {
     fn from(input: &Segment) -> Self {
         input.to_string()
     }
 }
 
-impl<T> From<T> for Segment
-where
-    T: AsRef<str>,
-{
-    fn from(input: T) -> Self {
-        Segment::new(input)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_make_fq_name() {
+        let segments = vec!["foo".to_string(), "bar".to_string()];
+        let fq_name = make_fq_name(&segments);
+        assert_eq!(fq_name, "foo_bar");
+    }
+
+    #[test]
+    fn test_new_segment_unique_name_for_qrl() {
+        let mut builder = SegmentBuilder::new();
+        let segments = vec![Segment::Named("foo".to_string())];
+        let segment = builder.new_segment("bar$", &segments);
+        assert_eq!(segment, Segment::NamedQrl("bar".to_string(), 0));
+
+        let segment = builder.new_segment("bar$", &segments);
+        assert_eq!(segment, Segment::NamedQrl("bar".to_string(), 1));
+    }
+
+    #[test]
+    fn test_new_segment_unique_name_for_anonymous_qrl() {
+        let mut builder = SegmentBuilder::new();
+        let segments = vec![Segment::Named("foo".to_string())];
+        let segment = builder.new_segment("$", &segments);
+        assert_eq!(segment, Segment::IndexQrl(0));
+
+        let segment = builder.new_segment("$", &segments);
+        assert_eq!(segment, Segment::IndexQrl(1));
+    }
+
+    #[test]
+    fn test_non_unique_for_non_qrl() {
+        let mut builder = SegmentBuilder::new();
+        let segments = vec![Segment::Named("foo".to_string())];
+        let segment = builder.new_segment("bar", &segments);
+        assert_eq!(segment, Segment::Named("bar".to_string()));
+
+        let segment = builder.new_segment("bar", &segments);
+        assert_eq!(segment, Segment::Named("bar".to_string()));
     }
 }

--- a/src/snapshots/qwik_optimizer__transform__tests__test_example_11_body.snap
+++ b/src/snapshots/qwik_optimizer__transform__tests__test_example_11_body.snap
@@ -3,4 +3,4 @@ source: src/transform.rs
 expression: result.body
 snapshot_kind: text
 ---
-"import { componentQrl, qrl } from \"@qwik.dev/core\";\nexport const Header = componentQrl(qrl(() => import(\"./test.tsx_Header_component_J4uyIhaBNR4\"), \"Header_component_J4uyIhaBNR4\"));\nexport const App = componentQrl(qrl(() => import(\"./test.tsx_App_component_ckEPmXZlub0\"), \"App_component_ckEPmXZlub0\"));\n"
+"import { qrl } from \"@qwik.dev/core\";\nimport { componentQrl } from \"@qwik.dev/core\";\nexport const Header = componentQrl(qrl(() => import(\"./test.tsx_Header_component_J4uyIhaBNR4\"), \"Header_component_J4uyIhaBNR4\"));\nexport const App = componentQrl(qrl(() => import(\"./test.tsx_App_component_ckEPmXZlub0\"), \"App_component_ckEPmXZlub0\"));\n"

--- a/src/snapshots/qwik_optimizer__transform__tests__test_example_1_body.snap
+++ b/src/snapshots/qwik_optimizer__transform__tests__test_example_1_body.snap
@@ -3,4 +3,4 @@ source: src/transform.rs
 expression: result.body
 snapshot_kind: text
 ---
-"import { component } from \"@qwik.dev/core\";\nimport { qrl } from \"@qwik.dev/core\";\nexport const renderHeader = qrl(() => import(\"./test.tsx_renderHeader_zBbHWn4e8Cg\"), \"renderHeader_zBbHWn4e8Cg\");\nconst renderHeader = component(qrl(() => import(\"./test.tsx_renderHeader_component_U6Kkv07sbpQ\"), \"renderHeader_component_U6Kkv07sbpQ\"));\n"
+"import { qrl } from \"@qwik.dev/core\";\nimport { component } from \"@qwik.dev/core\";\nexport const renderHeader = qrl(() => import(\"./test.tsx_renderHeader_zBbHWn4e8Cg\"), \"renderHeader_zBbHWn4e8Cg\");\nconst renderHeader = component(qrl(() => import(\"./test.tsx_renderHeader_component_U6Kkv07sbpQ\"), \"renderHeader_component_U6Kkv07sbpQ\"));\n"

--- a/src/snapshots/qwik_optimizer__transform__tests__test_example_2_body.snap
+++ b/src/snapshots/qwik_optimizer__transform__tests__test_example_2_body.snap
@@ -3,4 +3,4 @@ source: src/transform.rs
 expression: result.body
 snapshot_kind: text
 ---
-"import { component } from \"@qwik.dev/core\";\nimport { qrl } from \"@qwik.dev/core\";\nexport const renderHeader = qrl(() => import(\"./test.tsx_renderHeader_zBbHWn4e8Cg\"), \"renderHeader_zBbHWn4e8Cg\");\nconst renderHeader = component(qrl(() => import(\"./test.tsx_renderHeader_component_U6Kkv07sbpQ\"), \"renderHeader_component_U6Kkv07sbpQ\"));\n"
+"import { qrl } from \"@qwik.dev/core\";\nimport { component } from \"@qwik.dev/core\";\nexport const renderHeader = qrl(() => import(\"./test.tsx_renderHeader_zBbHWn4e8Cg\"), \"renderHeader_zBbHWn4e8Cg\");\nconst renderHeader = component(qrl(() => import(\"./test.tsx_renderHeader_component_U6Kkv07sbpQ\"), \"renderHeader_component_U6Kkv07sbpQ\"));\n"

--- a/src/snapshots/qwik_optimizer__transform__tests__test_example_3_body.snap
+++ b/src/snapshots/qwik_optimizer__transform__tests__test_example_3_body.snap
@@ -3,4 +3,4 @@ source: src/transform.rs
 expression: result.body
 snapshot_kind: text
 ---
-"import { componentQrl, qrl } from \"@qwik.dev/core\";\nexport const App = () => {\n\tconst Header = componentQrl(qrl(() => import(\"./test.tsx_App_Header_component_B9F3YeqcO1w\"), \"App_Header_component_B9F3YeqcO1w\"));\n\treturn Header;\n};\n"
+"import { qrl } from \"@qwik.dev/core\";\nimport { componentQrl } from \"@qwik.dev/core\";\nexport const App = () => {\n\tconst Header = componentQrl(qrl(() => import(\"./test.tsx_App_Header_component_B9F3YeqcO1w\"), \"App_Header_component_B9F3YeqcO1w\"));\n\treturn Header;\n};\n"

--- a/src/snapshots/qwik_optimizer__transform__tests__test_example_4_body.snap
+++ b/src/snapshots/qwik_optimizer__transform__tests__test_example_4_body.snap
@@ -3,4 +3,4 @@ source: src/transform.rs
 expression: result.body
 snapshot_kind: text
 ---
-"import { componentQrl, qrl } from \"@qwik.dev/core\";\nexport function App() {\n\tconst Header = componentQrl(qrl(() => import(\"./test.tsx_App_Header_component_B9F3YeqcO1w\"), \"App_Header_component_B9F3YeqcO1w\"));\n\treturn Header;\n}\n"
+"import { qrl } from \"@qwik.dev/core\";\nimport { componentQrl } from \"@qwik.dev/core\";\nexport function App() {\n\tconst Header = componentQrl(qrl(() => import(\"./test.tsx_App_Header_component_B9F3YeqcO1w\"), \"App_Header_component_B9F3YeqcO1w\"));\n\treturn Header;\n}\n"

--- a/src/snapshots/qwik_optimizer__transform__tests__test_example_5_body.snap
+++ b/src/snapshots/qwik_optimizer__transform__tests__test_example_5_body.snap
@@ -3,4 +3,4 @@ source: src/transform.rs
 expression: result.body
 snapshot_kind: text
 ---
-"import { componentQrl, qrl } from \"@qwik.dev/core\";\nexport const Header = componentQrl(qrl(() => import(\"./test.tsx_Header_component_J4uyIhaBNR4\"), \"Header_component_J4uyIhaBNR4\"));\n"
+"import { qrl } from \"@qwik.dev/core\";\nimport { componentQrl } from \"@qwik.dev/core\";\nexport const Header = componentQrl(qrl(() => import(\"./test.tsx_Header_component_J4uyIhaBNR4\"), \"Header_component_J4uyIhaBNR4\"));\n"

--- a/src/snapshots/qwik_optimizer__transform__tests__test_example_7_body.snap
+++ b/src/snapshots/qwik_optimizer__transform__tests__test_example_7_body.snap
@@ -3,4 +3,4 @@ source: src/transform.rs
 expression: result.body
 snapshot_kind: text
 ---
-"import { componentQrl, qrl } from \"@qwik.dev/core\";\nexport const Header = componentQrl(qrl(() => import(\"./test.tsx_Header_component_J4uyIhaBNR4\"), \"Header_component_J4uyIhaBNR4\"));\ncomponentQrl(qrl(() => import(\"./test.tsx_App_component_ckEPmXZlub0\"), \"App_component_ckEPmXZlub0\"));\n"
+"import { qrl } from \"@qwik.dev/core\";\nimport { componentQrl } from \"@qwik.dev/core\";\nexport const Header = componentQrl(qrl(() => import(\"./test.tsx_Header_component_J4uyIhaBNR4\"), \"Header_component_J4uyIhaBNR4\"));\ncomponentQrl(qrl(() => import(\"./test.tsx_App_component_ckEPmXZlub0\"), \"App_component_ckEPmXZlub0\"));\n"

--- a/src/snapshots/qwik_optimizer__transform__tests__test_example_8_body.snap
+++ b/src/snapshots/qwik_optimizer__transform__tests__test_example_8_body.snap
@@ -3,4 +3,4 @@ source: src/transform.rs
 expression: result.body
 snapshot_kind: text
 ---
-"import { componentQrl, qrl } from \"@qwik.dev/core\";\nexport const Header = componentQrl(qrl(() => import(\"./test.tsx_Header_component_J4uyIhaBNR4\"), \"Header_component_J4uyIhaBNR4\"));\n"
+"import { qrl } from \"@qwik.dev/core\";\nimport { componentQrl } from \"@qwik.dev/core\";\nexport const Header = componentQrl(qrl(() => import(\"./test.tsx_Header_component_J4uyIhaBNR4\"), \"Header_component_J4uyIhaBNR4\"));\n"

--- a/src/snapshots/qwik_optimizer__transform__tests__test_example_capture_imports_App_component_MB7xrsoro5g.snap
+++ b/src/snapshots/qwik_optimizer__transform__tests__test_example_capture_imports_App_component_MB7xrsoro5g.snap
@@ -1,0 +1,6 @@
+---
+source: src/transform.rs
+expression: comp.code
+snapshot_kind: text
+---
+"import { useStylesQrl, qrl } from \"@qwik.dev/core\";\nexport const App_component_MB7xrsoro5g = () => {\n\tuseStylesQrl(qrl(() => import(\"./test.jsx_App_component_useStyles_yj4sK3KtjRE\"), \"App_component_useStyles_yj4sK3KtjRE\"));\n\tuseStylesQrl(qrl(() => import(\"./test.jsx_App_component_useStyles_1_QaDDTipqmN4\"), \"App_component_useStyles_1_QaDDTipqmN4\"));\n};\n"

--- a/src/snapshots/qwik_optimizer__transform__tests__test_example_capture_imports_App_component_useStyles_1_QaDDTipqmN4.snap
+++ b/src/snapshots/qwik_optimizer__transform__tests__test_example_capture_imports_App_component_useStyles_1_QaDDTipqmN4.snap
@@ -1,0 +1,6 @@
+---
+source: src/transform.rs
+expression: comp.code
+snapshot_kind: text
+---
+"import css3 from \"./style.css\";\nexport const App_component_useStyles_1_QaDDTipqmN4 = css3;\n"

--- a/src/snapshots/qwik_optimizer__transform__tests__test_example_capture_imports_App_component_useStyles_yj4sK3KtjRE.snap
+++ b/src/snapshots/qwik_optimizer__transform__tests__test_example_capture_imports_App_component_useStyles_yj4sK3KtjRE.snap
@@ -1,0 +1,6 @@
+---
+source: src/transform.rs
+expression: comp.code
+snapshot_kind: text
+---
+"import css1 from \"./global.css\";\nimport css2 from \"./style.css\";\nexport const App_component_useStyles_yj4sK3KtjRE = `${css1}${css2}`;\n"

--- a/src/snapshots/qwik_optimizer__transform__tests__test_example_capture_imports_body.snap
+++ b/src/snapshots/qwik_optimizer__transform__tests__test_example_capture_imports_body.snap
@@ -1,0 +1,6 @@
+---
+source: src/transform.rs
+expression: result.body
+snapshot_kind: text
+---
+"import { qrl } from \"@qwik.dev/core\";\nimport { componentQrl } from \"@qwik.dev/core\";\nexport const App = componentQrl(qrl(() => import(\"./test.jsx_App_component_MB7xrsoro5g\"), \"App_component_MB7xrsoro5g\"));\n"

--- a/src/test_input/test_example_capture_imports.js
+++ b/src/test_input/test_example_capture_imports.js
@@ -1,0 +1,9 @@
+import { component$, useStyles$ } from '@qwik.dev/core';
+import css1 from './global.css';
+import css2 from './style.css';
+import css3 from './style.css';
+
+export const App = component$(() => {
+    useStyles$(`${css1}${css2}`);
+    useStyles$(css3);
+})


### PR DESCRIPTION
## Unique Naming of Qrls Fixes #20
There is now a unified unique-naming strategy for all qrl variants.

Previously, the implementation only work for \`return $\`.

Now unique names and Segments should work for any variant of qrl.

## Improved Import Handling, Fixes #21

New implementation is now reusing \`*$\` import declarations' internal symbols to maintain references correct.

Now, when a \`Qrl\` generates an internal \`ReferenceId\` it will look op in a xref table to see if an import exists and use the \`SymbolId\` with in the \`ReferenceId\`.  This allows for directly tracking imports that already exist instead repeatedly creating new imports for those that already exist.

Additionally, all qrl stacks that previously existed are now simply stored in \`qrl_stack\`,

## QrlComponent creation now handled in \`exit_call_expression\`, Fixes #26

This allows for much broader support for any type of call expression, not just those that wrapped an arrow function.