### PR TITLE
Fixes: #28 and #29

### DIFF
--- a/src/component/component.rs
+++ b/src/component/component.rs
@@ -21,12 +21,11 @@ impl QrlComponent {
         source_info: &SourceInfo,
         id: Id,
         exported_expression: Expression<'_>,
-        imports: Vec<CommonImport>,
+        imports: Vec<Import>,
         minify: bool,
         qrl_type: QrlType,
     ) -> QrlComponent {
         let language = source_info.language.clone();
-        // let id = Id::new(source_info, segments, target, scope);
         let qrl = Qrl::new(&id.local_file_name, &id.symbol_name, qrl_type);
 
         let source_type: SourceType = language.into();
@@ -50,7 +49,7 @@ impl QrlComponent {
     fn gen(
         id: &Id,
         exported_expression: Expression<'_>,
-        imports: Vec<CommonImport>,
+        imports: Vec<Import>,
         minify: bool,
         source_type: &SourceType,
         allocator: &Allocator,
@@ -144,7 +143,7 @@ impl QrlComponent {
     /// Create a QrlComponent from an `Expression`.
     pub(crate) fn from_expression(
         expr: Expression<'_>,
-        imports: Vec<CommonImport>,
+        imports: Vec<Import>,
         segments: &Vec<Segment>,
         target: &Target,
         scope: &Option<String>,
@@ -165,7 +164,7 @@ impl QrlComponent {
 
     pub(crate) fn from_call_expression_argument(
         arg: &Argument,
-        imports: Vec<CommonImport>,
+        imports: Vec<Import>,
         segments: &Vec<Segment>,
         target: &Target,
         scope: &Option<String>,

--- a/src/component/qrl.rs
+++ b/src/component/qrl.rs
@@ -1,4 +1,4 @@
-use crate::component::{CommonImport, Import, QRL, QRL_SUFFIX, QWIK_CORE_SOURCE};
+use crate::component::{Import, QRL, QRL_SUFFIX, QWIK_CORE_SOURCE};
 use crate::ext::AstBuilderExt;
 use oxc_allocator::{Allocator, Box as OxcBox, CloneIn, FromIn, IntoIn, Vec as OxcVec};
 use oxc_ast::ast::*;
@@ -16,15 +16,18 @@ pub enum QrlType {
     IndexedQrl(usize),
 }
 
-impl From<QrlType> for CommonImport {
+impl From<QrlType> for Import {
     fn from(value: QrlType) -> Self {
         match value {
-            QrlType::Qrl => CommonImport::qrl(),
-            QrlType::IndexedQrl(_) => CommonImport::qrl(),
-            QrlType::PrefixedQrl(prefix) => CommonImport::QwikCore(vec![
-                format!("{}{}", prefix, QRL_SUFFIX).as_str().into(),
-                QRL.into(),
-            ]),
+            QrlType::Qrl => Import::qrl(),
+            QrlType::IndexedQrl(_) => Import::qrl(),
+            QrlType::PrefixedQrl(prefix) => Import::new(
+                vec![
+                    format!("{}{}", prefix, QRL_SUFFIX).as_str().into(),
+                    QRL.into(),
+                ],
+                QWIK_CORE_SOURCE,
+            ),
         }
     }
 }

--- a/src/snapshots/qwik_optimizer__transform__tests__test_example_11_Header_component_J4uyIhaBNR4.snap
+++ b/src/snapshots/qwik_optimizer__transform__tests__test_example_11_Header_component_J4uyIhaBNR4.snap
@@ -3,4 +3,4 @@ source: src/transform.rs
 expression: comp.code
 snapshot_kind: text
 ---
-"import { qrl } from \"@qwik.dev/core\";\nimport { Header } from \"./test\";\nimport { bar as bbar } from \"../state\";\nimport * as dep2 from \"dep2\";\nexport const Header_component_J4uyIhaBNR4 = () => {\n\treturn <Header onClick={qrl(() => import(\"./test.tsx_Header_component_Header_onClick_oNOlojcAk6Q\"), \"Header_component_Header_onClick_oNOlojcAk6Q\")}>\n            {dep2.stuff()}{bbar()}\n        </Header>;\n};\n"
+"import { Header } from \"./test\";\nimport { qrl } from \"@qwik.dev/core\";\nimport { bar as bbar } from \"../state\";\nimport * as dep2 from \"dep2\";\nexport const Header_component_J4uyIhaBNR4 = () => {\n\treturn <Header onClick={qrl(() => import(\"./test.tsx_Header_component_Header_onClick_oNOlojcAk6Q\"), \"Header_component_Header_onClick_oNOlojcAk6Q\")}>\n            {dep2.stuff()}{bbar()}\n        </Header>;\n};\n"


### PR DESCRIPTION
## Better implementation for self-referencing. Fixes #28

The new implementation relies upon the recently implemented name-to-symbol-to-import-mechanism.

The new implementation will now support exported variables by adding their name, symbol and import (source of import is the is pulled from SourceInfo.)

## Remove \`CommonImport\` Fixes: #29

We really only need `Import`, having the additional layer of `CommonExport` provides no benefit and only serves to over-complicate the code base.